### PR TITLE
require のエラー文言修正

### DIFF
--- a/docs/3-ETH-NFT-game/ja/section-2/Lesson_1_ボスキャラを作成して攻撃のロジックを実装しよう.md
+++ b/docs/3-ETH-NFT-game/ja/section-2/Lesson_1_ボスキャラを作成して攻撃のロジックを実装しよう.md
@@ -115,7 +115,7 @@ function attackBoss() public {
 	// 3. ボスのHPが0以上であることを確認する。
 	require (
 		bigBoss.hp > 0,
-		"Error: boss must have HP to attack boss."
+		"Error: boss must have HP to attack characters."
 	);
 
 	// 4. プレイヤーがボスを攻撃できるようにする。


### PR DESCRIPTION
## 変更内容
おそらくNFTキャラクターを攻撃するためだと思うので、require のエラー文言を
"Error: boss must have HP to attack boss" から "Error: boss must have HP to attack characters." に変更

## 背景

## 備考

<!-- 該当ページの URL -->
https://unchain-portal.netlify.app/projects/3-ETH-NFT-game/section-2-Lesson-1

<!-- 影響範囲など -->