### PR TITLE
コントラクトのライセンスをMITに修正

### DIFF
--- a/docs/1-ETH-dApp/ja/section-1/Lesson_2_Solidityでスマートコントラクトを作成しよう.md
+++ b/docs/1-ETH-dApp/ja/section-1/Lesson_2_Solidityでスマートコントラクトを作成しよう.md
@@ -37,7 +37,7 @@ VS Code をターミナルから起動する方法は [こちら](https://maku.b
 `WavePortal.sol` を VS Code で開き、下記を入力します。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.4;
 
@@ -54,7 +54,7 @@ contract WavePortal {
 
 ```javascript
 // WavePortal.sol
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 ```
 
 これは「SPDX ライセンス識別子」と呼ばれ、ソフトウェア・ライセンスの種類が一目でわかるようにするための識別子です。

--- a/docs/1-ETH-dApp/ja/section-1/Lesson_4_スマートコントラクトにデータを保存しよう.md
+++ b/docs/1-ETH-dApp/ja/section-1/Lesson_4_スマートコントラクトにデータを保存しよう.md
@@ -15,7 +15,7 @@
 それでは、「👋（wave）」を保存するために、`WavePortal.sol` を更新していきましょう。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.4;
 

--- a/docs/1-ETH-dApp/ja/section-3/Lesson_1_ブロックチェーン上にデータを保存しよう.md
+++ b/docs/1-ETH-dApp/ja/section-3/Lesson_1_ブロックチェーン上にデータを保存しよう.md
@@ -13,7 +13,7 @@
 それでは、`WavePortal.sol` を更新していきます。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 import "hardhat/console.sol";
 contract WavePortal {

--- a/docs/1-ETH-dApp/ja/section-4/Lesson_1_WEBアプリに抽選機能を実装しよう.md
+++ b/docs/1-ETH-dApp/ja/section-4/Lesson_1_WEBアプリに抽選機能を実装しよう.md
@@ -7,7 +7,7 @@
 これを防ぐために、これから下記の機能を `WavePortal.sol` に実装していきます。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.4;
 
@@ -291,7 +291,7 @@ Contract balance: 0.0999
 それでは、下記のように `WavePortal.sol` を更新しましょう。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.4;
 

--- a/docs/2-ETH-NFT-collection/ja/section-1/Lesson_3_ローカル環境でNFTをmintしよう.md
+++ b/docs/2-ETH-NFT-collection/ja/section-1/Lesson_3_ローカル環境でNFTをmintしよう.md
@@ -28,7 +28,7 @@ epic-nfts
 `MyEpicNFT.sol` のファイル内に以下のコードを記載します。
 
 ```solidity
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 import "hardhat/console.sol";
 contract MyEpicNFT {
@@ -51,7 +51,7 @@ contract MyEpicNFT {
 さて、行ごとにコードをみていきましょう。
 
 ```solidity
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 ```
 
 これは「SPDX ライセンス識別子」と呼ばれます。

--- a/docs/2-ETH-NFT-collection/ja/section-1/Lesson_4_NFTを発行するスマートコントラクトを作ろう.md
+++ b/docs/2-ETH-NFT-collection/ja/section-1/Lesson_4_NFTを発行するスマートコントラクトを作ろう.md
@@ -5,7 +5,7 @@
 下記のように、`MyEpicNFT.sol`を更新しましょう。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 // いくつかの OpenZeppelin のコントラクトをインポートします。
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";

--- a/docs/2-ETH-NFT-collection/ja/section-2/Lesson_3_ブロックチェーン上で動的なSVGを作ろう.md
+++ b/docs/2-ETH-NFT-collection/ja/section-2/Lesson_3_ブロックチェーン上で動的なSVGを作ろう.md
@@ -7,7 +7,7 @@
 下記のように、`MyEpicNFT.sol` を更新していきましょう。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.4;
 
@@ -394,7 +394,7 @@ library Base64 {
 `MyEpicNFT.sol` も下記のように更新しましょう。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.4;
 

--- a/docs/2-ETH-NFT-collection/ja/section-4/Lesson_1_WEBアプリをアップグレードしよう.md
+++ b/docs/2-ETH-NFT-collection/ja/section-4/Lesson_1_WEBアプリをアップグレードしよう.md
@@ -221,7 +221,7 @@ const setupEventListener = async () => {
 
 ```javascript
 // MyEpicNFT.sol
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.4;
 

--- a/docs/3-ETH-NFT-game/ja/section-1/Lesson_3_スマートコントラクトを作ろう.md
+++ b/docs/3-ETH-NFT-game/ja/section-1/Lesson_3_スマートコントラクトを作ろう.md
@@ -31,7 +31,7 @@ VS Code をターミナルから起動する方法は[こちら](https://maku.bl
 それでは、これから `MyEpicGame.sol` の中身の作成していきます。`MyEpicGame.sol` を VS Code で開き、下記を入力します。
 
 ```javascript
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.4;
 
@@ -50,7 +50,7 @@ contract MyEpicGame {
 
 ```javascript
 // MyEpicGame.sol
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 ```
 
 これは「SPDX ライセンス識別子」と呼ばれ、ソフトウェア・ライセンスの種類が一目でわかるようにするための識別子です。

--- a/docs/4-Polygon-Generative-NFT/ja/section-2/Lesson_1_スマートコントラクトを作ろう.md
+++ b/docs/4-Polygon-Generative-NFT/ja/section-2/Lesson_1_スマートコントラクトを作ろう.md
@@ -186,7 +186,7 @@ contract NFTCollectible is ERC721Enumerable, Ownable {
 
 ```javascript
 // NFTCollectible.sol
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 ```
 
 これは「SPDX ライセンス識別子」と呼ばれ、ソフトウェア・ライセンスの種類が一目でわかるようにするための識別子です。


### PR DESCRIPTION
## 変更内容
resolve #115

UNLICENSEDとして誤ってライセンスされてしまっていたコントラクトのサンプルコード（15か所）を、MIT Licenseでライセンスしなおす

## 背景
UNLICENSEDはプロプライエタリを示す識別子（厳密にはinvalid）であり、MITでライセンスされている本プロジェクトとのライセンスの整合性がとれていなかった。詳しくは #115 を参照のこと

## 備考
N/A