### PR TITLE
upload to github

### DIFF
--- a/docs/104-ETH-NFT-Game/ja/section-3/Lesson_2_ウォレット接続のボタンを作ろう.md
+++ b/docs/104-ETH-NFT-Game/ja/section-3/Lesson_2_ウォレット接続のボタンを作ろう.md
@@ -45,7 +45,7 @@ const App = () => {
           <p className="header gradient-text">⚡️ METAVERSE GAME ⚡️</p>
           <p className="sub-text">プレイヤーと協力してボスを倒そう!</p>
           <div className="connect-wallet-container">
-            <img src="https://i.imgur.com/yMocj5x.png" alt="Pikachu" />
+            <img src="https://i.imgur.com/TXBQ4cC.png" alt="LUFFY" />
           </div>
         </div>
         <div className="footer-container">
@@ -147,7 +147,7 @@ const App = () => {
           <p className="header gradient-text">⚡️ METAVERSE GAME ⚡️</p>
           <p className="sub-text">プレイヤーと協力してボスを倒そう!</p>
           <div className="connect-wallet-container">
-            <img src="https://i.imgur.com/yMocj5x.png" alt="Pikachu" />
+            <img src="https://i.imgur.com/TXBQ4cC.png" alt="LUFFY" />
           </div>
         </div>
         <div className="footer-container">
@@ -275,7 +275,7 @@ const App = () => {
           <p className="header gradient-text">⚡️ METAVERSE GAME ⚡️</p>
           <p className="sub-text">プレイヤーと協力してボスを倒そう!</p>
           <div className="connect-wallet-container">
-            <img src="https://i.imgur.com/yMocj5x.png" alt="Pikachu" />
+            <img src="https://i.imgur.com/TXBQ4cC.png" alt="LUFFY" />
             {/*
              * ウォレットコネクトを起動するために使用するボタンを設定しています。
              * メソッドを呼び出すために onClick イベントを追加することを忘れないでください。

--- a/docs/104-ETH-NFT-Game/ja/section-3/Lesson_3_WEBアプリの初期状態をセットアップしよう.md
+++ b/docs/104-ETH-NFT-Game/ja/section-3/Lesson_3_WEBアプリの初期状態をセットアップしよう.md
@@ -112,7 +112,7 @@ const renderContent = () => {
   if (!currentAccount) {
     return (
       <div className="connect-wallet-container">
-        <img src="https://i.imgur.com/yMocj5x.png" alt="Pikachu" />
+        <img src="https://i.imgur.com/TXBQ4cC.png" alt="LUFFY" />
         <button
           className="cta-button connect-wallet-button"
           onClick={connectWalletAction}

--- a/docs/104-ETH-NFT-Game/ja/section-3/Lesson_6_ボスとのバトルフィールドを作ろう.md
+++ b/docs/104-ETH-NFT-Game/ja/section-3/Lesson_6_ボスとのバトルフィールドを作ろう.md
@@ -93,7 +93,7 @@ const renderContent = () => {
   if (!currentAccount) {
     return (
       <div className="connect-wallet-container">
-        <img src="https://i.imgur.com/yMocj5x.png" alt="Pikachu" />
+        <img src="https://i.imgur.com/TXBQ4cC.png" alt="LUFFY" />
         <button
           className="cta-button connect-wallet-button"
           onClick={connectWalletAction}


### PR DESCRIPTION
## 変更内容
「ETH NFT GAME」を教材通りに進めますと、ウォレット非接続時に「ルフィー」でなく、「ピカチュウ」が表示されます。
教材内で「ピカチュウ」画像がリンクされている部分を「ルフィー」に変更しました。
## 背景
「Discord」にUPされている完成後同プロジェクトを確認しますと、「ピカチュウ」・「ルフィー」まちまちでした。
Section4 Lesson3の完成デモ画面はルフィーになっていましたので、そのようにいたした。
