### PR TITLE
upload to github

### DIFF
--- a/docs/103-ETH-NFT-Maker/ja/section-4/Lesson_1_Webアプリをアップデートしよう.md
+++ b/docs/103-ETH-NFT-Maker/ja/section-4/Lesson_1_Webアプリをアップデートしよう.md
@@ -29,11 +29,6 @@ contract Web3Mint is ERC721{
 
     NftAttributes[] Web3Nfts;
 
-    mapping(uint256 => NftAttributes) public nftHolderAttributes;
-    mapping(address => uint256) public nftHolder;
-
-
-
     constructor() ERC721("NFT","nft"){
         console.log("This is my NFT contract.");
     }


### PR DESCRIPTION
## 変更内容
ETH-NFT-MAKER section4-lesson1 デバッグ用に公開されてます Web3Mint.sol ですが、教材通りに進めますと表示されない２行があることに気が付きましたので削除しました。

## 背景
"nftHolderAttributes"と"nftHolder"、双方、定義されたのち使用されてないように思われます。
試しに２行削除してデプロイしてみましたが、特段不都合は見られませんでした。

## 備考
該当箇所をgyazoにUPしました。

<!-- 該当ページの URL -->
https://gyazo.com/09124540275adbedfef0651e03e21cd8

