### PR TITLE
Update Lesson_2_UIをアップグレードして自分だけのオリジナルアプリを作ろう.md

### DIFF
--- a/docs/101-ETH-dApp/ja/section-4/Lesson_2_UIをアップグレードして自分だけのオリジナルアプリを作ろう.md
+++ b/docs/101-ETH-dApp/ja/section-4/Lesson_2_UIをアップグレードして自分だけのオリジナルアプリを作ろう.md
@@ -80,7 +80,7 @@ let contractBalance_post = await provider.getBalance(
   wavePortalContract.address
 );
 /* コントラクトの残高が減っていることを確認 */
-if (contractBalance_post < contractBalance) {
+if (contractBalance_post.lt(contractBalance)) {
   /* 減っていたら下記を出力 */
   console.log("User won ETH!");
 } else {


### PR DESCRIPTION
## 変更内容
ユーザーが ETH を獲得したか検証での、残高比較ロジックの修正

## 背景
単純な `<` での比較だとオブジェクトの文字列表現での比較になるため、桁がずれる場合に正しく計算できない。

```js
"9999" < "10000" // のような時にfalseとなる
```

## 備考
- https://unchain-portal.netlify.app/projects/101-ETH-dApp/section-4-Lesson-2
