### PR TITLE
jsファイルのコントラクトの宣言の部分をMockDaiToken→DaiTokenへ修正

### DIFF
--- a/docs/105-Ganache-Yield-Farm/ja/section-2/Lesson_1_トークンを作成しよう.md
+++ b/docs/105-Ganache-Yield-Farm/ja/section-2/Lesson_1_トークンを作成しよう.md
@@ -28,7 +28,7 @@
 // 2_deploy_contracts.js
 const TokenFarm = artifacts.require(`TokenFarm`)
 const DappToken = artifacts.require(`DappToken`)
-const DaiToken = artifacts.require(`MockDaiToken`)
+const DaiToken = artifacts.require(`DaiToken`)
 
 module.exports = async function(deployer, newtwork, accounts) {
 
@@ -57,7 +57,7 @@ module.exports = async function(deployer, newtwork, accounts) {
 // 2_deploy_contracts.js
 const TokenFarm = artifacts.require(`TokenFarm`)
 const DappToken = artifacts.require(`DappToken`)
-const DaiToken = artifacts.require(`MockDaiToken`)
+const DaiToken = artifacts.require(`DaiToken`)
 ```
 
 ここでは`TokenFarm`, `DappToken`, `MockDaiToken`の3つのコントラクトとやりとりをするよとtruffleに伝えています。


### PR DESCRIPTION
jsファイルのコントラクトの宣言の部分ですが、MockDaiToken.sol内にcontract DaiTokenで定義されていたので、修正前が正しかったように思えます。
すみません。。。

## 変更内容

## 背景

## 備考

<!-- 該当ページの URL -->
<!-- 影響範囲など -->
