### PR TITLE
SocketException: OS Error: Connection refused, errno = 111, address = localhost, port = 41027の修正

### DIFF
--- a/docs/203-Polygon-Mobile-dApp/ja/section-2/Lesson_2_Flutterでフロントを開発しよう（ロジック編）.md
+++ b/docs/203-Polygon-Mobile-dApp/ja/section-2/Lesson_2_Flutterでフロントを開発しよう（ロジック編）.md
@@ -89,6 +89,10 @@ class TodoListModel extends ChangeNotifier {
 ```
 
 Ganache の `_rpcUrl` と `_wsUrl` をローカル環境用に設定しています。
+* Android向けにEmulatorを使ってDebugビルドをする場合は_rpcUrlをhttp://10.0.2.2:7545に変更する必要があります
+> また、開発マシンのアドレス 127.0.0.1 は、エミュレータ固有のループバック インターフェースと一致することになります。開発マシンのループバック インターフェース（マシン上の別名 127.0.0.1）で実行されているサービスにアクセスする場合は、代わりに特殊アドレス 10.0.2.2 を使用する必要があります。
+(参照: https://developer.android.com/studio/run/emulator-networking)
+
 
 ```dart
   final String _privateKey =


### PR DESCRIPTION
## 背景

203-Polygon-Mobile-dAppのsection-2-Lesson-2においてデバッグビルドした際に
getTodosメソッドの `await _client!.call(contract: _contract!, function: _taskCount!, params: []);` が実行されると
SocketException: OS Error: Connection refused, errno = 111, address = localhost, port = 41027のエラーになります

環境
AndroidStudio/Emulator


## 変更内容

[公式ドキュメント](https://developer.android.com/studio/run/emulator-networking)の以下の記載に従ってネットワークアドレスを変更したところ解決したので、AndoirdEmulatorの場合の記載を追記しました

> また、開発マシンのアドレス 127.0.0.1 は、エミュレータ固有のループバック インターフェースと一致することになります。開発マシンのループバック インターフェース（マシン上の別名 127.0.0.1）で実行されているサービスにアクセスする場合は、代わりに特殊アドレス 10.0.2.2 を使用する必要があります。

## 備考
該当ページの URL: https://unchain-portal.netlify.app/projects/203-Polygon-Mobile-dApp/section-2-Lesson-2

