### PR TITLE
401-NEAR-Election-dApp section-0-Lesson-2の修正

### DIFF
--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -148,7 +148,7 @@ https://asapoon.com/error/2795/command-not-found-yarn/
 
 まずは下のコマンドをターミナルで実行することで Tailwind のインストールと config ファイルの生成をします。
 
-注意点として、このコマンドをターミナルで実行するのは先ほど作成したフロントエンドのディレクトリである`near-election-dapp-frontend`です（名前を変えた方はその名前）。
+注意点として、このコマンドをターミナルで実行するのは先ほど作成したフロントエンドのディレクトリである`near-election-dapp-frontend`（名前を変えた方はその名前）にある`frontend`ディレクトリです。
 
 ```bash
 npm install -D tailwindcss postcss &&  npx tailwindcss init
@@ -198,7 +198,13 @@ module.exports = {
 
 まず near-election-dapp-frontend/frontend/App.js の 58 行目を下のようにかえます。
 
-次にターミナル上で`near-election-dapp-frontend`に移動して、`yarn dev`を実行してみましょう！
+次にターミナル上で`near-election-dapp-frontend`に移動して、
+```bash
+yarn build:web
+yarn start
+```
+
+を実行してみましょう！
 
 [App.js]
 

--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -83,10 +83,9 @@ cargo new near-election-dapp-contract --lib
 次にフロントエンドのセッティングもしていきます。`near-election-dapp`ディレクトリにいることを確認して以下のコードを実行しましょう。
 
 ```bash
-npx create-near-app --frontend=react --contract=rust near-election-dapp-frontend
+npx create-near-app near-election-dapp-frontend --contract rust --frontend react --t
+ests js
 ```
-
-コードを入力すると、2回ほどYes、Noを問われると思うので、全てYesを選択するで大丈夫です。
 
 これによってコントラクトとフロントの接続をすでにコーディングしてくれている状態のプロジェクトを作成してくれます。
 
@@ -130,7 +129,9 @@ https://dot-blog.jp/news/homebrew-how-to-install/
 ここで`near-election-dapp-frontend`へ移って下のコマンドをターミナルで実行すると、あらかじめ用意されているコントラクトのコンパイルとデプロイがされた後にフロントエンドが起動されます！
 
 ```bash
-yarn dev
+yarn build
+yarn deploy
+yarn start
 ```
 
 その結果下のようになっているはずです。

--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -231,7 +231,6 @@ near-election-dapp/
 └── near-election-dapp-frontend/
     ├── README.md
     ├── ava.config.cjs
-    ├── contract/
     ├── dist/
     ├── frontend/
     ├── integration-tests/

--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -83,7 +83,7 @@ cargo new near-election-dapp-contract --lib
 次にフロントエンドのセッティングもしていきます。`near-election-dapp`ディレクトリにいることを確認して以下のコードを実行しましょう。
 
 ```bash
-npx create-near-app --frontend=react --contract=rust near-election-dapp-frontend
+npx create-near-app@3.1.0 --frontend=react --contract=rust near-election-dapp-frontend
 ```
 
 コードを入力すると、2回ほどYes、Noを問われると思うので、全てYesを選択するで大丈夫です。

--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -148,7 +148,7 @@ https://asapoon.com/error/2795/command-not-found-yarn/
 
 まずは下のコマンドをターミナルで実行することで Tailwind のインストールと config ファイルの生成をします。
 
-注意点として、このコマンドをターミナルで実行するのは先ほど作成したフロントエンドのディレクトリである`near-election-dapp-frontend`（名前を変えた方はその名前）にある`frontend`ディレクトリです。
+注意点として、このコマンドをターミナルで実行するのは先ほど作成したフロントエンドのディレクトリである`near-election-dapp-frontend`です（名前を変えた方はその名前）。
 
 ```bash
 npm install -D tailwindcss postcss &&  npx tailwindcss init
@@ -198,13 +198,7 @@ module.exports = {
 
 まず near-election-dapp-frontend/frontend/App.js の 58 行目を下のようにかえます。
 
-次にターミナル上で`near-election-dapp-frontend`に移動して、
-```bash
-yarn build:web
-yarn start
-```
-
-を実行してみましょう！
+次にターミナル上で`near-election-dapp-frontend`に移動して、`yarn dev`を実行してみましょう！
 
 [App.js]
 

--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -83,9 +83,10 @@ cargo new near-election-dapp-contract --lib
 次にフロントエンドのセッティングもしていきます。`near-election-dapp`ディレクトリにいることを確認して以下のコードを実行しましょう。
 
 ```bash
-npx create-near-app near-election-dapp-frontend --contract rust --frontend react --t
-ests js
+npx create-near-app --frontend=react --contract=rust near-election-dapp-frontend
 ```
+
+コードを入力すると、2回ほどYes、Noを問われると思うので、全てYesを選択するで大丈夫です。
 
 これによってコントラクトとフロントの接続をすでにコーディングしてくれている状態のプロジェクトを作成してくれます。
 
@@ -129,9 +130,7 @@ https://dot-blog.jp/news/homebrew-how-to-install/
 ここで`near-election-dapp-frontend`へ移って下のコマンドをターミナルで実行すると、あらかじめ用意されているコントラクトのコンパイルとデプロイがされた後にフロントエンドが起動されます！
 
 ```bash
-yarn build
-yarn deploy
-yarn start
+yarn dev
 ```
 
 その結果下のようになっているはずです。

--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -196,7 +196,7 @@ module.exports = {
 
 これで tailwind の設定は完了したのできちんと機能しているか確認してみましょう。
 
-まず near-election-dapp-frontend/frontend/ui-components.js の 17 行目を下のようにかえます。
+まず near-election-dapp-frontend/frontend/App.js の 58 行目を下のようにかえます。
 
 次にターミナル上で`near-election-dapp-frontend`に移動して、
 ```bash

--- a/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
+++ b/docs/NEAR-Election-dApp/ja/section-0/Lesson_2_環境構築をしよう.md
@@ -196,7 +196,7 @@ module.exports = {
 
 これで tailwind の設定は完了したのできちんと機能しているか確認してみましょう。
 
-まず near-election-dapp-frontend/frontend/App.js の 58 行目を下のようにかえます。
+まず near-election-dapp-frontend/frontend/ui-components.js の 17 行目を下のようにかえます。
 
 次にターミナル上で`near-election-dapp-frontend`に移動して、
 ```bash


### PR DESCRIPTION
## 変更内容
- `npx create-near-app`でプロジェクトを作成する際のコマンドのエラーの修正
```
npx create-near-app --frontend=react --contract=rust near-election-dapp-frontend
Arguments error
Run npx create-near-app without arguments, or use:
npx create-near-app <projectName> --contract rust|js --frontend react|vanilla|none --tests js|rust
```
- `yarn dev`がない
```
  "scripts": {
    "start": "cd frontend && npm run start",
    "deploy": "cd contract && ./deploy.sh",
    "build": "npm run build:contract && npm run build:web",
    "build:web": "cd frontend && npm run build",
    "build:contract": "cd contract && ./build.sh",
    "test": "npm run test:unit && npm run test:integration",
    "test:unit": "cd contract && cargo test",
    "test:integration": "cd integration-tests && npm test -- -- \"./contract/target/wasm32-unknown-unknown/release/hello_near.wasm\"",
    "postinstall": "cd frontend && npm install && cd .. && cd integration-tests && npm install && cd .. && echo rs contract"
  },
```
- tailwind導入部分の修正
- ディレクトリ構成のtypo
## 背景
`create-near-app`の最新バーションの問題なのか、ドキュメント通りに進めても動作しない部分がありました。
## 備考
https://unchain-portal.netlify.app/projects/401-NEAR-Election-dApp/section-0-Lesson-2

レビューよろしくお願いいたします:bow:

