### PR TITLE
change ownable function visibility

### DIFF
--- a/docs/AVAX-messenger/ja/section-3/Lesson_1_コントラクトに管理者を設けよう.md
+++ b/docs/AVAX-messenger/ja/section-3/Lesson_1_コントラクトに管理者を設けよう.md
@@ -270,7 +270,7 @@ pragma solidity ^0.8.9;
 contract Ownable {
     address public owner;
 
-    function ownable() public {
+    function ownable() internal {
         owner = msg.sender;
     }
 


### PR DESCRIPTION
## 変更内容
`ownable`関数のアクセス修飾子を`internal`に変更しました。

## 背景
`ownable`が`public`だと他のユーザに実行されて管理者を変更されてしまうと思います。

## 備考

<!-- 該当ページの URL -->
<!-- 影響範囲など -->
