### PR TITLE
fix eth-nft-collection docs

### DIFF
--- a/docs/ETH-NFT-Collection/ja/section-2/Lesson_3_ブロックチェーン上で動的なSVGを作ろう.md
+++ b/docs/ETH-NFT-Collection/ja/section-2/Lesson_3_ブロックチェーン上で動的なSVGを作ろう.md
@@ -707,6 +707,8 @@ Minted NFT #1
 下記のように、あなたの SquareNFT が OpenSea で確認できたでしょうか？
 ![](/public/images/ETH-NFT-Collection/section-2/2_3_3.png)
 
+OpenSea上で画像が表示されない場合は[Rarible](https://testnet.rarible.com/)で検索してみてください。
+
 ### 🙋‍♂️ 質問する
 
 ここまでの作業で何かわからないことがある場合は、Discord の `#eth-nft-collection` で質問をしてください。


### PR DESCRIPTION
## 変更内容
デプロイしたNFTをOpenSea上で検索して確認するステップがありますが、OpenSeaだと画像が表示されないケースがあります。
その場合でも[Rarible](https://testnet.rarible.com/)では正常に表示されているので、Raribleで確認する旨のメッセージを追記しました。

## 背景
Discord上で同様の事象の報告が複数ある
* https://discord.com/channels/936573458748432405/946074847602167848/1031137215968985148
* https://discord.com/channels/936573458748432405/946074847602167848/1031411918256214056
* https://discord.com/channels/936573458748432405/946074847602167848/1031474846611284039

## 備考

該当ページの URL
https://app.unchain.tech/learn/ETH-NFT-Collection/section-2_lesson-3