### PR TITLE
fix typo in docs

### DIFF
--- a/docs/NEAR-Hotel-Booking-dApp/ja/section-1/Lesson_2_データを読み書きするメソッドを実装しよう.md
+++ b/docs/NEAR-Hotel-Booking-dApp/ja/section-1/Lesson_2_データを読み書きするメソッドを実装しよう.md
@@ -35,7 +35,7 @@ impl Default for Contract
 ```
 
 関数の中では、`rooms_per_owner`と`rooms_by_id`のインスタンスを`new()`で生成しています。
-// TODO: newの引数について説明を入れる（違い）。
+<!-- TODO: newの引数について説明を入れる（違い）。-->
 `LookupMap`は`new()`に`b"m"`を引数に渡します。これは、`new()`が`LookupMap`のインスタンスを生成する際に、キーの一意なプレフィックスを設置するためです。`b"..."`は、バイト文字列リテラルを生成する`Rust`のキーワードです。
 
 ```rust
@@ -267,7 +267,7 @@ pub fn exists(&self, owner_id: AccountId, room_name: String) -> bool {
 +                 }
 + 
 +                 // 取得した部屋のデータをもとに、`RegisteredRoom`構造体を生成
-+                 let resigtered_room = RegisteredRoom {
++                 let registered_room = RegisteredRoom {
 +                     name: room.name.clone(),
 +                     beds: room.beds,
 +                     image: room.image.clone(),
@@ -277,7 +277,7 @@ pub fn exists(&self, owner_id: AccountId, room_name: String) -> bool {
 +                     status: room_status,
 +                 };
 +                 // Vectorに追加
-+                 registered_rooms.push(resigtered_room);
++                 registered_rooms.push(registered_room);
 +             }
 +             registered_rooms
 +         }
@@ -346,7 +346,7 @@ pub fn get_rooms_registered_by_owner(&self, owner_id: AccountId) -> Vec<Register
 
 ```rust
                     // 取得した部屋のデータをもとに、`RegisteredRoom`構造体を生成
-                    let resigtered_room = RegisteredRoom {
+                    let registered_room = RegisteredRoom {
                         name: room.name.clone(),
                         beds: room.beds,
                         image: room.image.clone(),
@@ -356,7 +356,7 @@ pub fn get_rooms_registered_by_owner(&self, owner_id: AccountId) -> Vec<Register
                         status: room_status,
                     };
                     // Vectorに追加
-                    registered_rooms.push(resigtered_room);
+                    registered_rooms.push(registered_room);
                 }
                 registered_rooms
             }


### PR DESCRIPTION
## 変更内容

38行目：

```
// TODO: newの引数について説明を入れる（違い）。
```
コメントアウトできていなかったため修正しました。


270, 280, 349, 359行目：

```
resigtered_room
```

resigterd_room  -> registerd_room に修正しました。