### PR TITLE
fix: fix Avalanche-Messenger to Avax-AMM in AVAX-AMM

### DIFF
--- a/docs/AVAX-AMM/ja/section-4/Lesson_1_Webアプリをデプロイしよう.md
+++ b/docs/AVAX-AMM/ja/section-4/Lesson_1_Webアプリをデプロイしよう.md
@@ -10,7 +10,7 @@ Vercelに関する詳しい説明は,[こちら](https://zenn.dev/lollipop_onl/a
 
 まず, ローカルファイルをGitHubへアップロードしましょう。
 
-まだアップロードをしていない方は, ターミナル上で`Avalanche-Messenger`に移動して,下記を実行しましょう。  
+まだアップロードをしていない方は, ターミナル上で`Avax-AMM`に移動して,下記を実行しましょう。  
 ⚠️ `.gitignore`ファイル内に`.env`が記載されていることを確認していください。
 
 ```
@@ -19,7 +19,7 @@ git commit -m "upload to github"
 git push
 ```
 
-次に, ローカル環境に存在する`Avalanche-Messenger`のファイルとディレクトリがGitHub上の`Avalanche-Messenger`に反映されていることを確認してください。
+次に, ローカル環境に存在する`Avax-AMM`のファイルとディレクトリがGitHub上の`Avax-AMM`に反映されていることを確認してください。
 
 Vercelのアカウントを取得したら,下記を実行しましょう。
 


### PR DESCRIPTION
## 変更内容
AVAX-AMMプロジェクト内にて、`Avalanche-Messenger`ディレクトリを操作する表記があったが、これを`Avax-AMM`に変更

## 背景
開発環境作成時には`mkdir Avax-AMM`を実行しているので`Avax-AMM`が正しいと思われる

## 備考

<該当ページの URL>
https://app.unchain.tech/learn/AVAX-AMM/section-4_lesson-1

<影響範囲など>
ないと思われる。